### PR TITLE
add peci driver patch for Arbel EVB

### DIFF
--- a/linux/peci/0001-driver-peci-modify-gcr-lookup.patch
+++ b/linux/peci/0001-driver-peci-modify-gcr-lookup.patch
@@ -1,0 +1,71 @@
+From 069c2c5dd50c8447fd13aaa6620fa8bd92efa51f Mon Sep 17 00:00:00 2001
+From: kfting <kfting@nuvoton.com>
+Date: Tue, 27 Jul 2021 10:49:01 +0800
+Subject: [PATCH] driver : peci : modify gcr lookup
+
+Signed-off-by: kfting <kfting@nuvoton.com>
+---
+ arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi | 1 +
+ arch/arm64/configs/npcm8xx_defconfig                    | 1 +
+ drivers/mfd/intel-peci-client.c                         | 6 ++++++
+ drivers/peci/busses/peci-npcm.c                         | 3 +--
+ 4 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+index ae08d2d6f9b8..059c51781e03 100644
+--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
++++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+@@ -1753,6 +1753,7 @@
+ 		#size-cells = <0>;
+ 		interrupts = <GIC_SPI 6 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&clk NPCM8XX_CLK_APB3>;
++		syscon = <&gcr>;
+ 		status = "disabled";
+ 	};
+ };
+diff --git a/arch/arm64/configs/npcm8xx_defconfig b/arch/arm64/configs/npcm8xx_defconfig
+index 3b0ead5bd88b..6dad9ef774ff 100644
+--- a/arch/arm64/configs/npcm8xx_defconfig
++++ b/arch/arm64/configs/npcm8xx_defconfig
+@@ -126,6 +126,7 @@ CONFIG_PCI=y
+ CONFIG_PCIE_NPCM=y
+ CONFIG_PECI=y
+ CONFIG_PECI_NPCM=y
++CONFIG_PECI_CHARDEV=y
+ CONFIG_MFD_INTEL_PECI_CLIENT=y
+ CONFIG_SENSORS_PECI_CPUTEMP=y
+ CONFIG_SENSORS_PECI_DIMMTEMP=y
+diff --git a/drivers/mfd/intel-peci-client.c b/drivers/mfd/intel-peci-client.c
+index 18bf0af0e09e..a326bcc89d1e 100644
+--- a/drivers/mfd/intel-peci-client.c
++++ b/drivers/mfd/intel-peci-client.c
+@@ -43,6 +43,12 @@ static const struct cpu_gen_info cpu_gen_info_table[] = {
+ 		.core_max      = CORE_MAX_ON_SKX,
+ 		.chan_rank_max = CHAN_RANK_MAX_ON_SKX,
+ 		.dimm_idx_max  = DIMM_IDX_MAX_ON_SKX },
++	{ /* Skylake Xeon */
++		.family        = 6, /* Family code */
++		.model         = 5,
++		.core_max      = CORE_MAX_ON_SKX,
++		.chan_rank_max = CHAN_RANK_MAX_ON_SKX,
++		.dimm_idx_max  = DIMM_IDX_MAX_ON_SKX },
+ 	{ /* Skylake Xeon D */
+ 		.family        = 6, /* Family code */
+ 		.model         = INTEL_FAM6_SKYLAKE_XD,
+diff --git a/drivers/peci/busses/peci-npcm.c b/drivers/peci/busses/peci-npcm.c
+index 675d2c618a91..6341a33d1c68 100644
+--- a/drivers/peci/busses/peci-npcm.c
++++ b/drivers/peci/busses/peci-npcm.c
+@@ -222,8 +222,7 @@ static int npcm_peci_init_ctrl(struct npcm_peci *priv)
+ 
+ 	if (of_device_is_compatible(priv->dev->of_node,
+ 				    "nuvoton,npcm750-peci")) {
+-		priv->gcr_regmap = syscon_regmap_lookup_by_compatible
+-			("nuvoton,npcm750-gcr");
++		priv->gcr_regmap = syscon_regmap_lookup_by_phandle(priv->dev->of_node, "syscon");
+ 		if (!IS_ERR(priv->gcr_regmap)) {
+ 			bool volt = of_property_read_bool(priv->dev->of_node,
+ 							  "high-volt-range");
+-- 
+2.17.1
+


### PR DESCRIPTION
1. Based on https://github.com/Nuvoton-Israel/linux/commit/11d43c703af8e11f3c620199f6c3f8a0cc566cde.
2. The kernel branch is https://github.com/Nuvoton-Israel/linux/tree/NPCM-5.10-OpenBMC.
3. Based on kernel 5.10.14.
3. If an Intel test kit is used, the following settings are recommended for the test kit:
   GetDIB 04 31 00 00 00 00 00 00
   RdPkgConfig 50 06 00 00
4. For OpenBMC peci test, add libpeci.

Signed-off-by: kfting <kfting@nuvoton.com>